### PR TITLE
fix: make grammar generator task depend on interop processing task

### DIFF
--- a/languages/java/build.gradle.kts
+++ b/languages/java/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
                 defFileProperty.set(generateTask.interopFile.asFile)
                 includeDirs.allHeaders(grammarDir.resolve("bindings/c"))
                 extraOpts("-libraryPath", libsDir.dir(konanTarget.name))
-                tasks.getByName(interopProcessingTaskName).mustRunAfter(generateTask)
+                tasks.getByName(interopProcessingTaskName).dependsOn(generateTask)
             }
         }
     }


### PR DESCRIPTION
`mustRunAfter` is used for ordering two tasks, without adding dependency between the tasks. `dependsOn` should be used here to create a dependency on the grammar generator task, since the interop processing task uses the output of `generateGrammarFiles`.

From the [Gradle docs](https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api/-task/must-run-after.html) :

> ```
> task taskY {
>    mustRunAfter "taskX"
> }
> ```
> 
> For each supplied task, this action adds a task 'ordering', and does not specify a 'dependency' between the tasks. As such, it is still possible to execute 'taskY' without first executing the 'taskX' in the example.

This also fixes a build issue that occurs when the `kotlin-tree-sitter` project is included as a composite Gradle build, where the interop processing task fails because one of its input files (interop file `grammar.def`) is unavailable (because `generateGrammarFiles` is never executed).