### PR TITLE
Publish iosSimulatorArm64 artifact

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,6 +118,7 @@ jobs:
               :ktreesitter:publishMacosX64PublicationToLocalRepository
               :ktreesitter:publishMacosArm64PublicationToLocalRepository
               :ktreesitter:publishIosArm64PublicationToLocalRepository
+              :ktreesitter:publishIosSimulatorArm64PublicationToLocalRepository
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

Add the publishIosSimulatorArm64PublicationToLocalRepository task to the iOS matrix entry in the publish workflow, so the `iosSimulatorArm64` artifact ships to Maven Central alongside the other Apple targets to make local development easy with this lib.

## Background

https://github.com/tree-sitter/kotlin-tree-sitter/blob/87cbf7e0689a8013fc134b0d1d48a47bde975ecb/ktreesitter/build.gradle.kts#L52 already declares iosSimulatorArm64 as a Kotlin/Native target, but the publish workflow never invokes the corresponding publish task. As a result, `io.github.tree-sitter:ktreesitter-iossimulatorarm64` has never been uploaded to Maven Central, which makes the library unusable on the iOS simulator on Apple Silicon Mac.

The other Apple targets (macosArm64, macosX64, iosArm64) have single-artifact publications on Maven Central, so this looks like an oversight rather than an intentional exclusion.

## Note on a separate issue (out of scope for this PR)

While verifying the fix, I noticed that the root Gradle Module Metadata at https://repo.maven.apache.org/maven2/io/github/tree-sitter/ktreesitter/0.24.1/ktreesitter-0.24.1.module

only lists variants for jvm, androidJvm and linux. No macOS, iOS, or mingw variants are referenced.

This is caused by the common job in the publish workflow running on ubuntu-latest, where the host-OS branching in below only registers Linux native targets — so when `publishKotlinMultiplatformPublicationToLocalRepository` runs, the root metadata produces has no Apple or Windows variants.

https://github.com/tree-sitter/kotlin-tree-sitter/blob/87cbf7e0689a8013fc134b0d1d48a47bde975ecb/ktreesitter/build.gradle.kts#L45-L58

- - -

As a consequence, even after this PR ships the iosSimulatorArm64 artifact, consumers using `commonMain { implementation("io.github.tree-sitter:ktreesitter:<version>") }` still cannot resolve the dependency for Apple targets — they have to depend on the per-target coordinates such as ktreesitter-iossimulatorarm64 directly.

Happy to file a separate issue or PR for the root metadata problem if that is welcome. This PR is intentionally scoped to the smaller, obvious fix.
