### PR TITLE
Replace setup-konan-action in docs/publish workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,20 +44,15 @@ jobs:
           cache-dependency-path: |
             gradle/libs.versions.toml
             gradle/wrapper/gradle-wrapper.properties
-      - name: Set up Kotlin/Native
-        uses: ObserverOfTime/setup-konan-action@v1
+      - name: Cache Kotlin/Native dependencies
+        uses: actions/cache@v5
         with:
-          kotlin_version: 2.2.10
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ runner.arch }}-2.2.10
       - name: Set up cross compilation
-        if: matrix.platform == 'Linux'
         run: |-
           sudo apt-get update
           sudo apt-get install -qy {binutils,gcc}-aarch64-linux-gnu
-      - name: Set up Ninja
-        if: matrix.platform == 'Android'
-        run: |-
-          sudo apt-get update
-          sudo apt-get install -qy ninja-build
       - name: Build documentation
         run: >-
           ./gradlew --no-daemon -Pcmake.version=3.31.6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -132,10 +132,11 @@ jobs:
           cache-dependency-path: |
             gradle/libs.versions.toml
             gradle/wrapper/gradle-wrapper.properties
-      - name: Set up Kotlin/Native
-        uses: ObserverOfTime/setup-konan-action@v1
+      - name: Cache Kotlin/Native dependencies
+        uses: actions/cache@v5
         with:
-          kotlin_version: 2.2.10
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ runner.arch }}-2.2.10
       - name: Set up cross compilation
         if: matrix.platform == 'Linux'
         run: |-
@@ -154,6 +155,9 @@ jobs:
           pattern: ktreesitter-lib-*
           merge-multiple: true
       - name: Build packages
+        # Force bash on Windows runners so PowerShell does not split
+        # `-Pcmake.version=3.31.6` into separate tokens.
+        shell: bash
         run: ./gradlew --no-daemon -Pcmake.version=3.31.6 ${{matrix.targets}}
         env:
           SIGNING_KEY: ${{secrets.SIGNING_KEY}}
@@ -229,10 +233,11 @@ jobs:
           cache-dependency-path: |
             gradle/libs.versions.toml
             gradle/wrapper/gradle-wrapper.properties
-      - name: Set up Kotlin/Native
-        uses: ObserverOfTime/setup-konan-action@v1
+      - name: Cache Kotlin/Native dependencies
+        uses: actions/cache@v5
         with:
-          kotlin_version: 2.2.10
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ runner.arch }}-2.2.10
       - name: Publish Gradle plugin
         run: ./gradlew --no-daemon :ktreesitter-plugin:publishPlugins
         env:


### PR DESCRIPTION
## Summary

Apply the same swap as pull request workflows: https://github.com/tree-sitter/kotlin-tree-sitter/pull/64 to docs and publish workflows

## Changes

- Change to cache ~/.konan with actions/cache and let Gradle download the Kotlin/Native toolchain.
- Add `shell: bash` to the publish.yml build step so PowerShell does not split `-Pcmake.version=3.31.6` on Windows runners.
- Remove matrix platform check from docs.yml because of only ubuntu-latest use

## Note

I haven't been able to actually run these workflows, but the errors that came up in the dokka build were the same ones fixed in #64, and publish.yml does roughly the same things as ci.yml, so I don't expect any issues.