### PR TITLE
 Bump ABI to 15 for Kotlin/Native to match JVM and Android

### DIFF
--- a/ktreesitter/src/commonMain/kotlin/io/github/treesitter/ktreesitter/TreeSitter.kt
+++ b/ktreesitter/src/commonMain/kotlin/io/github/treesitter/ktreesitter/TreeSitter.kt
@@ -10,7 +10,7 @@ package io.github.treesitter.ktreesitter
  * The Tree-sitter library is generally backwards-compatible with languages
  * generated using older CLI versions, but is not forwards-compatible.
  */
-const val LANGUAGE_VERSION: UInt = 14U
+const val LANGUAGE_VERSION: UInt = 15U
 
 /** The earliest ABI version that is supported by the current version of the library. */
 const val MIN_COMPATIBLE_LANGUAGE_VERSION: UInt = 13U


### PR DESCRIPTION
## Summary

Bump `LANGUAGE_VERSION` in `commonMain` from `14U` to `15U` to allow ABI 15 languages to be loaded on Kotlin/Native (closes #62 follow-up).

Kotlin/Native is the only target that gates ABI on this constant. JVM/Android already accept ABI 15 via the JNI `language_check_version` implementation, which reads `TREE_SITTER_LANGUAGE_VERSION` from the tree-sitter C header directly: https://github.com/tree-sitter/tree-sitter/blob/release-0.25/lib/include/tree_sitter/api.h#L29

Loading an ABI 15 language on a Kotlin/Native target currently fails with: `kotlin.IllegalArgumentException: Incompatible language version 15. Must be between 13 and 14.`

thrown from the `init` block here:
https://github.com/tree-sitter/kotlin-tree-sitter/blob/6d71c3bd08af7e42c6e751fefc05432a11fd7293/ktreesitter/src/nativeMain/kotlin/io/github/treesitter/ktreesitter/Language.kt#L36-L41

## Note

Like Jvm/Android, having every module reference the values from `api.h` directly would probably be cleaner, but since it depends on the design direction, I haven't changed that in this PR.