### PR TITLE
Use UTF-8 byte offsets for multibyte source

### DIFF
--- a/ktreesitter/src/commonTest/kotlin/io/github/treesitter/ktreesitter/NodeTest.kt
+++ b/ktreesitter/src/commonTest/kotlin/io/github/treesitter/ktreesitter/NodeTest.kt
@@ -224,6 +224,12 @@ class NodeTest : FunSpec({
         rootNode.descendant(6U, 9U)?.text() shouldBe "Foo"
     }
 
+    test("text() with multibyte content before the node") {
+        val multibyteSource = "// 日本語日本語日本語\nclass Foo {}"
+        val multibyteTree = Parser(language).parse(multibyteSource)
+        multibyteTree.rootNode.descendant(37U, 40U)?.text() shouldBe "Foo"
+    }
+
     test("sexp()") {
         rootNode.child(0U)!!.sexp() shouldBe
             "(class_declaration name: (identifier) body: (class_body))"

--- a/ktreesitter/src/commonTest/kotlin/io/github/treesitter/ktreesitter/ParserTest.kt
+++ b/ktreesitter/src/commonTest/kotlin/io/github/treesitter/ktreesitter/ParserTest.kt
@@ -57,6 +57,13 @@ class ParserTest : FunSpec({
         tree.text()?.subSequence(13, 15) shouldBe "\uD83D\uDCA9"
     }
 
+    test("parse(source) with multibyte input") {
+        parser.language = Language(TreeSitterJava.language())
+        val source = "class Foo { String s = \"café 日本語\"; }"
+        val tree = parser.parse(source)
+        tree.rootNode.endByte shouldBe source.encodeToByteArray().size.toUInt()
+    }
+
     test("parse(readCallback)") {
         val source = "class Foo {}"
         val tree = parser.parse { byte, _ ->

--- a/ktreesitter/src/jvmMain/kotlin/io/github/treesitter/ktreesitter/Node.kt
+++ b/ktreesitter/src/jvmMain/kotlin/io/github/treesitter/ktreesitter/Node.kt
@@ -309,8 +309,11 @@ actual class Node internal constructor(
     actual fun walk() = TreeCursor(this)
 
     /** Get the source code of the node, if available. */
-    actual fun text() = tree.text()?.run {
-        subSequence(startByte.toInt(), minOf(endByte.toInt(), length))
+    actual fun text(): CharSequence? = tree.text()?.run {
+        val bytes = toString().encodeToByteArray()
+        val start = startByte.toInt().coerceIn(0, bytes.size)
+        val end = endByte.toInt().coerceIn(start, bytes.size)
+        bytes.decodeToString(start, end)
     }
 
     /** Get the S-expression of the node. */

--- a/ktreesitter/src/nativeMain/kotlin/io/github/treesitter/ktreesitter/Node.kt
+++ b/ktreesitter/src/nativeMain/kotlin/io/github/treesitter/ktreesitter/Node.kt
@@ -352,8 +352,11 @@ actual class Node internal constructor(
     actual fun walk() = TreeCursor(this)
 
     /** Get the source code of the node, if available. */
-    actual fun text() = tree.text()?.run {
-        subSequence(startByte.toInt(), minOf(endByte.toInt(), length))
+    actual fun text(): CharSequence? = tree.text()?.run {
+        val bytes = toString().encodeToByteArray()
+        val start = startByte.toInt().coerceIn(0, bytes.size)
+        val end = endByte.toInt().coerceIn(start, bytes.size)
+        bytes.decodeToString(start, end)
     }
 
     /** Get the S-expression of the node. */

--- a/ktreesitter/src/nativeMain/kotlin/io/github/treesitter/ktreesitter/Parser.kt
+++ b/ktreesitter/src/nativeMain/kotlin/io/github/treesitter/ktreesitter/Parser.kt
@@ -118,7 +118,7 @@ actual class Parser actual constructor() {
             self,
             oldTree?.self,
             source,
-            source.length.convert(),
+            source.encodeToByteArray().size.convert(),
             encoding.value
         )
         checkNotNull(tree) { "Parsing failed" }
@@ -155,7 +155,7 @@ actual class Parser actual constructor() {
             read = staticCFunction { payload, index, point, bytes ->
                 val data = payload!!.asStableRef<ParsePayload>().get()
                 val result = data.callback(index, point.useContents { convert() })
-                bytes!!.pointed.value = result?.length?.convert() ?: 0U
+                bytes!!.pointed.value = result?.toString()?.encodeToByteArray()?.size?.convert() ?: 0U
                 result?.toString()?.cstr?.getPointer(data.memScope)
             }
         }

--- a/ktreesitter/src/nativeMain/kotlin/io/github/treesitter/ktreesitter/Parser.kt
+++ b/ktreesitter/src/nativeMain/kotlin/io/github/treesitter/ktreesitter/Parser.kt
@@ -154,9 +154,9 @@ actual class Parser actual constructor() {
             this.encoding = encoding.value
             read = staticCFunction { payload, index, point, bytes ->
                 val data = payload!!.asStableRef<ParsePayload>().get()
-                val result = data.callback(index, point.useContents { convert() })
-                bytes!!.pointed.value = result?.toString()?.encodeToByteArray()?.size?.convert() ?: 0U
-                result?.toString()?.cstr?.getPointer(data.memScope)
+                val result = data.callback(index, point.useContents { convert() })?.toString()
+                bytes!!.pointed.value = result?.encodeToByteArray()?.size?.convert() ?: 0U
+                result?.cstr?.getPointer(data.memScope)
             }
         }
         var progressRef: StableRef<ParseProgressCallback>? = null


### PR DESCRIPTION
## Summary

Non-ASCII (multibyte) source was mishandled in two related places. One is Kotlin/Native-only; the other affects **both** Kotlin/Native and JVM/Android.

### 1. `Parser.parse` passed the wrong byte length (Native only)

`nativeMain` `Parser.parse` passed `source.length` — the UTF-16 code-unit count — as the UTF-8 byte length to `ts_parser_parse_string_encoding`

```kotlin
ts_parser_parse_string_encoding(self, oldTree?.self, source, source.length.convert(), encoding.value)
```

Kotlin/Native marshals `String` to a **UTF-8** C string, so for any multibyte input the declared length is smaller than the actual byte length and the parser truncates the input, dropping every token past the truncation point. The JNI path is unaffected because it uses `GetStringUTFLength`.

### 2. `Node.text()` sliced a UTF-16 String with UTF-8 offsets

`Node.text()` (identical in `nativeMain` and `jvmMain`) slices the source `String` (UTF-16 char-indexed) using `startByte`/`endByte`, which are tree-sitter **UTF-8 byte offsets**:

```kotlin
actual fun text() = tree.text()?.run {
    subSequence(startByte.toInt(), minOf(endByte.toInt(), length))
}
```

`endByte` is clamped to `length` but `startByte` is not, so once a node begins after enough multibyte content that `startByte > length` (UTF-16), `subSequence` throws. Predicate evaluation (`#eq?`/`#match?`/`#any-of?`) calls `Node.text()`, so this crashes query execution on multibyte source; when it doesn't crash it silently returns the wrong substring. This is reachable on the JVM independently of defect (1) (JVM parse lengths were always correct).

- - -

These two fixes must land together: fix (1) alone would turn silent truncation into a hard crash, because it removes the accidental bound that was masking fix (2)'s out-of-range access.


## Changes

- `nativeMain` `Parser.parse`: pass `source.encodeToByteArray().size` as the byte length, in both the string and read-callback paths.
- `Node.text()` (native and jvm): slice in UTF-8 byte space, then decode.

```kotlin
actual fun text(): CharSequence? = tree.text()?.run {
    val bytes = toString().encodeToByteArray()
    val start = startByte.toInt().coerceIn(0, bytes.size)
    val end = endByte.toInt().coerceIn(start, bytes.size)
    bytes.decodeToString(start, end)
}
```

Node boundaries are token boundaries, i.e. valid UTF-8 boundaries, so decoding `[start, end)` is safe.


## Crash logs

Kotlin/Native (iOS Simulator):

```
Uncaught Kotlin exception: kotlin.ArrayIndexOutOfBoundsException
  kfun:io.github.treesitter.ktreesitter.Node#text(){}kotlin.CharSequence?   ← crash
  kfun:...QueryPredicate.EqString#invoke(QueryMatch)
  kfun:...QueryCursor.convert#internal
  kfun:...QueryCursor.captures...
```

JVM (Android):

```
java.lang.StringIndexOutOfBoundsException: begin 648, end 613, length 613
    at java.lang.String.subSequence(String.java:2587)
    at io.github.treesitter.ktreesitter.Node.text(Node.kt:326)
    at io.github.treesitter.ktreesitter.QueryPredicate$EqString.invoke...
    at io.github.treesitter.ktreesitter.QueryCursor$captures$2.invokeSuspend
```

`begin 648` is a UTF-8 byte offset; `length 613` is the UTF-16 char count.

## Screenshots

incorrect `Parser.parse` sample | after fixed
:--: | :--:
<img width="360" alt="Simulator Screenshot - iPhone 17 - 2026-07-02 at 14 56 37" src="https://github.com/user-attachments/assets/aabce8f6-40af-4c51-bc1e-ec6045af01c1" /> | <img width="360" alt="Simulator Screenshot - iPhone 17 - 2026-07-02 at 15 12 32" src="https://github.com/user-attachments/assets/6ebccb98-113a-4dbd-a0ff-2f5a5f653cdc" />

