### PR TITLE
Encode parse input with real UTF-8/UTF-16 instead of modified UTF-8

### DIFF
--- a/ktreesitter/src/jni/module.c
+++ b/ktreesitter/src/jni/module.c
@@ -179,6 +179,9 @@ JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *_reserved) {
     CACHE_CLASS("java/lang/", CharSequence);
     CACHE_METHOD(CharSequence, toString, "toString", "()Ljava/lang/String;");
 
+    CACHE_CLASS("java/lang/", String);
+    CACHE_METHOD(String, getBytes, "getBytes", "(Ljava/lang/String;)[B");
+
     CACHE_CLASS("java/util/", ArrayList);
     CACHE_METHOD(ArrayList, init, "<init>", "(I)V");
     CACHE_METHOD(ArrayList, add, "add", "(Ljava/lang/Object;)Z");
@@ -252,6 +255,7 @@ JNIEXPORT void JNI_OnUnload(JavaVM *vm, void *_reserved) {
     (*env)->DeleteGlobalRef(env, global_class_cache.QueryCapture);
     (*env)->DeleteGlobalRef(env, global_class_cache.QueryMatch);
     (*env)->DeleteGlobalRef(env, global_class_cache.Range);
+    (*env)->DeleteGlobalRef(env, global_class_cache.String);
     (*env)->DeleteGlobalRef(env, global_class_cache.Tree);
     (*env)->DeleteGlobalRef(env, global_class_cache.TreeCursor);
     (*env)->DeleteGlobalRef(env, global_class_cache.Triple);

--- a/ktreesitter/src/jni/parser.c
+++ b/ktreesitter/src/jni/parser.c
@@ -5,9 +5,10 @@
 typedef struct {
     JNIEnv *env;
     jobject callback;
+    TSInputEncoding encoding;
     struct {
-        jstring string;
-        const char *chars;
+        jbyteArray array;
+        jbyte *bytes;
     } last_result;
 } ReadPayload;
 
@@ -25,6 +26,35 @@ static inline TSInputEncoding get_encoding(JNIEnv *env, jobject encoding) {
         return TSInputEncodingUTF16BE;
     }
     UNREACHABLE();
+}
+
+static inline const char *get_charset(TSInputEncoding encoding) {
+    switch (encoding) {
+        case TSInputEncodingUTF16LE:
+            return "UTF-16LE";
+        case TSInputEncodingUTF16BE:
+            return "UTF-16BE";
+        default:
+            return "UTF-8";
+    }
+}
+
+static inline jbyteArray encode_string(JNIEnv *env, jstring string, TSInputEncoding encoding) {
+    jstring charset = (*env)->NewStringUTF(env, get_charset(encoding));
+    jbyteArray array = (jbyteArray)CALL_METHOD(Object, string, String_getBytes, charset);
+    (*env)->DeleteLocalRef(env, charset);
+    return array;
+}
+
+static inline void release_read_result(ReadPayload *read_payload) {
+    JNIEnv *env = read_payload->env;
+    jbyteArray array = read_payload->last_result.array;
+    if (array != NULL) {
+        (*env)->ReleaseByteArrayElements(env, array, read_payload->last_result.bytes, JNI_ABORT);
+        (*env)->DeleteLocalRef(env, array);
+        read_payload->last_result.array = NULL;
+        read_payload->last_result.bytes = NULL;
+    }
 }
 
 static void log_function(void *payload, TSLogType log_type, const char *buffer) {
@@ -58,11 +88,8 @@ static const char *parse_read_callback(void *payload, uint32_t byte_index, TSPoi
                                        uint32_t *bytes_read) {
     ReadPayload *read_payload = (ReadPayload *)payload;
     JNIEnv *env = read_payload->env;
-    jstring last_string = read_payload->last_result.string;
-    const char *last_chars = read_payload->last_result.chars;
-    if (last_string) {
-        (*env)->ReleaseStringUTFChars(env, last_string, last_chars);
-    }
+    release_read_result(read_payload);
+    *bytes_read = 0;
 
     jobject point = marshal_point(env, position);
     jobject byte = (*env)->AllocObject(env, global_class_cache.UInt);
@@ -81,11 +108,16 @@ static const char *parse_read_callback(void *payload, uint32_t byte_index, TSPoi
     if ((*env)->ExceptionCheck(env))
         return NULL;
 
-    const char *result = (*env)->GetStringUTFChars(env, string, NULL);
-    *bytes_read = (uint32_t)(*env)->GetStringUTFLength(env, string);
-    read_payload->last_result.string = string;
-    read_payload->last_result.chars = result;
-    return result;
+    jbyteArray array = encode_string(env, string, read_payload->encoding);
+    (*env)->DeleteLocalRef(env, string);
+    if ((*env)->ExceptionCheck(env))
+        return NULL;
+
+    jbyte *bytes = (*env)->GetByteArrayElements(env, array, NULL);
+    *bytes_read = (uint32_t)(*env)->GetArrayLength(env, array);
+    read_payload->last_result.array = array;
+    read_payload->last_result.bytes = bytes;
+    return (const char *)bytes;
 }
 
 static bool parse_progress_callback(TSParseState *state) {
@@ -181,13 +213,17 @@ jobject JNICALL parser_parse__string(JNIEnv *env, jobject this, jstring source, 
     }
 
     TSTree *old_ts_tree = old_tree ? GET_POINTER(TSTree, old_tree, Tree_self) : NULL;
-    uint32_t length;
-    const char *string = (*env)->GetStringUTFChars(env, source, NULL);
-    length = (uint32_t)(*env)->GetStringUTFLength(env, source);
     TSInputEncoding input_encoding = get_encoding(env, encoding);
-    TSTree *ts_tree =
-        ts_parser_parse_string_encoding(self, old_ts_tree, string, length, input_encoding);
-    (*env)->ReleaseStringUTFChars(env, source, string);
+    jbyteArray array = encode_string(env, source, input_encoding);
+    if ((*env)->ExceptionCheck(env))
+        return NULL;
+
+    jbyte *bytes = (*env)->GetByteArrayElements(env, array, NULL);
+    uint32_t length = (uint32_t)(*env)->GetArrayLength(env, array);
+    TSTree *ts_tree = ts_parser_parse_string_encoding(self, old_ts_tree, (const char *)bytes,
+                                                      length, input_encoding);
+    (*env)->ReleaseByteArrayElements(env, array, bytes, JNI_ABORT);
+    (*env)->DeleteLocalRef(env, array);
 
     if (ts_tree == NULL) {
         const char *error = "Parsing failed";
@@ -209,8 +245,8 @@ jobject JNICALL parser_parse__function(JNIEnv *env, jobject this, jobject encodi
     }
     TSTree *old_ts_tree = old_tree ? GET_POINTER(TSTree, old_tree, Tree_self) : NULL;
 
-    ReadPayload read_payload = {.env = env, .callback = read_callback};
     TSInputEncoding input_encoding = get_encoding(env, encoding);
+    ReadPayload read_payload = {.env = env, .callback = read_callback, .encoding = input_encoding};
     TSInput input = {
         .payload = (void *)&read_payload,
         .read = parse_read_callback,
@@ -227,6 +263,7 @@ jobject JNICALL parser_parse__function(JNIEnv *env, jobject this, jobject encodi
         };
         ts_tree = ts_parser_parse_with_options(self, old_ts_tree, input, options);
     }
+    release_read_result(&read_payload);
 
     if ((*env)->ExceptionCheck(env)) {
         (*env)->Throw(env, (*env)->ExceptionOccurred(env));

--- a/ktreesitter/src/jni/utils.h
+++ b/ktreesitter/src/jni/utils.h
@@ -127,6 +127,7 @@ typedef struct {
     jmethodID QueryError$Syntax_init;
     jmethodID QueryMatch_init;
     jmethodID Range_init;
+    jmethodID String_getBytes;
     jmethodID Tree_init;
     jmethodID Triple_init;
 } MethodCache;
@@ -161,6 +162,7 @@ typedef struct {
     jclass QueryError$Syntax;
     jclass QueryMatch;
     jclass Range;
+    jclass String;
     jclass Tree;
     jclass TreeCursor;
     jclass Triple;

--- a/ktreesitter/src/jvmTest/kotlin/io/github/treesitter/ktreesitter/ParserEncodingTest.kt
+++ b/ktreesitter/src/jvmTest/kotlin/io/github/treesitter/ktreesitter/ParserEncodingTest.kt
@@ -1,0 +1,28 @@
+package io.github.treesitter.ktreesitter
+
+import io.github.treesitter.ktreesitter.java.TreeSitterJava
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ParserEncodingTest : FunSpec({
+    val parser = Parser().apply { language = Language(TreeSitterJava.language()) }
+    val source = "class Foo { String s = \"🎉🎉\"; }"
+
+    test("parse(source) encodes astral characters as UTF-8") {
+        val tree = parser.parse(source)
+        tree.rootNode.hasError shouldBe false
+        tree.rootNode.endByte shouldBe source.encodeToByteArray().size.toUInt()
+    }
+
+    test("parse(readCallback) encodes astral characters as UTF-8") {
+        val tree = parser.parse { byte, _ -> if (byte == 0U) source else null }
+        tree.rootNode.hasError shouldBe false
+        tree.rootNode.endByte shouldBe source.encodeToByteArray().size.toUInt()
+    }
+
+    test("parse(source) encodes UTF-16 input as UTF-16") {
+        val tree = parser.parse(source, encoding = InputEncoding.UTF_16LE)
+        tree.rootNode.hasError shouldBe false
+        tree.rootNode.endByte shouldBe (source.length * 2).toUInt()
+    }
+})


### PR DESCRIPTION
## Context

closes https://github.com/tree-sitter/kotlin-tree-sitter/issues/82

## Changes

- Encode the parse input with `String.getBytes`, using the charset matching the `InputEncoding`, instead of `GetStringUTFChars` / `GetStringUTFLength`. This applies to both the string overload and the read callback, so the parser now receives real UTF-8 (astral characters as 4 bytes, no MUTF-8 offset shift) and the UTF-16LE/BE overload receives actual UTF-16 bytes.
- Set `*bytes_read = 0` when the read callback returns `NULL`. Without this, tree-sitter keeps the previous chunk size and dereferences a `NULL` chunk, crashing the JVM in `ts_decode_utf8` whenever the callback returns `null` after returning data (reproducible on `master`).
- Release the read callback's buffer properly: keep it pinned until the next invocation and free the final chunk after parsing, which was previously leaked. Cache `java/lang/String` and its `getBytes` method id following the existing `JNI_OnLoad` convention.
- Add `ParserEncodingTest` (jvmTest) covering the string overload and the read callback with astral characters, plus the UTF-16LE string overload.

## Note

ParserEncodingTest uses astral characters, and on Kotlin/Native the string overload currently truncates multibyte input for an unrelated reason (`source.length` is passed as the byte length), which #78 fixes. It should be moved to `commonTest` after merged.